### PR TITLE
fix: Should rotate agent log

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ $ npm i egg-logrotator
 - `plugin.js`
 
 ```js
-exports.logrotator = true;
+exports.logrotator = {
+  enable: true,
+  package: 'egg-logrotator',
+};
 ```
 
 - `config.default.js`

--- a/app/lib/day_rotator.js
+++ b/app/lib/day_rotator.js
@@ -22,6 +22,13 @@ class DayRotator extends Rotator {
     for (const key in loggers) {
       this._setFile(loggers[key].options.file, files);
     }
+    // Should rotate agent log, because schedule is running under app worker,
+    // agent log is the only differece between app worker and agent worker.
+    // - app worker -> egg-web.log
+    // - agent worker -> egg-agent.log
+    const logDir = this.app.config.logger.dir;
+    const agentLogName = this.app.config.logger.agentLogName;
+    this._setFile(path.join(logDir, agentLogName), files);
 
     // rotateLogDirs is deprecated
     const rotateLogDirs = this.app.config.logger.rotateLogDirs;

--- a/test/fixtures/logrotator-agent/app.js
+++ b/test/fixtures/logrotator-agent/app.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function(app) {
+  // won't find egg-agent from rotateLogDirs
+  app.config.logger.rotateLogDirs = [];
+};

--- a/test/fixtures/logrotator-agent/config/config.default.js
+++ b/test/fixtures/logrotator-agent/config/config.default.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  logger: {
+    agentLogName: 'my-agent.log',
+  },
+};

--- a/test/fixtures/logrotator-agent/package.json
+++ b/test/fixtures/logrotator-agent/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "logrotator-agent",
+  "private":true
+}

--- a/test/logrotator.test.js
+++ b/test/logrotator.test.js
@@ -330,6 +330,30 @@ describe('test/logrotator.test.js', () => {
     });
 
   });
+
+  describe('agent logger', () => {
+    let app;
+    before(() => {
+      app = mm.app({
+        baseDir: 'logrotator-agent',
+        cache: false,
+      });
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should be rotated', function* () {
+      const logDir = app.config.logger.dir;
+      const now = moment().startOf('date');
+      const date = now.clone().subtract(1, 'days').format('YYYY-MM-DD');
+      const schedule = path.join(__dirname, '../app/schedule/rotate_by_file');
+      yield app.runSchedule(schedule);
+
+      assert(fs.existsSync(path.join(logDir, `my-agent.log.${date}`)));
+    });
+
+  });
+
 });
 
 function sleep(ms) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

DayRotator

##### Description of change
<!-- Provide a description of the change below this comment. -->

because schedule is running under app worker,
agent log is the only differece between app worker and agent worker.
- app worker -> egg-web.log
- agent worker -> egg-agent.log