### PR TITLE
fix: in for in loop add hasOwnProperty filter

### DIFF
--- a/app/lib/day_rotator.js
+++ b/app/lib/day_rotator.js
@@ -21,10 +21,12 @@ class DayRotator extends Rotator {
     const files = new Map();
     const loggers = this.app.loggers;
     for (const key in loggers) {
-      const logger = loggers[key];
-      this._setFile(logger.options.file, files);
-      if (logger.options.jsonFile) {
-        this._setFile(logger.options.jsonFile, files);
+      if (loggers.hasOwnProperty(key)) {
+        const logger = loggers[key];
+        this._setFile(logger.options.file, files);
+        if (logger.options.jsonFile) {
+          this._setFile(logger.options.jsonFile, files);
+        }
       }
     }
 

--- a/app/schedule/clean_log.js
+++ b/app/schedule/clean_log.js
@@ -15,9 +15,11 @@ module.exports = app => ({
     const logger = app.coreLogger;
     const logDirs = [];
     for (const key in app.loggers) {
-      const logDir = path.dirname(app.loggers[key].options.file);
-      if (logDirs.indexOf(logDir) === -1) {
-        logDirs.push(logDir);
+      if (app.loggers.hasOwnProperty(key)) {
+        const logDir = path.dirname(app.loggers[key].options.file);
+        if (logDirs.indexOf(logDir) === -1) {
+          logDirs.push(logDir);
+        }
       }
     }
 

--- a/test/logrotator.test.js
+++ b/test/logrotator.test.js
@@ -138,6 +138,15 @@ describe('test/logrotator.test.js', () => {
       const date = now.clone().subtract(1, 'days').format('YYYY-MM-DD');
       assert(fs.existsSync(path.join(logDir, `hour.log.${date}`)) === false);
     });
+
+    it('should not nerror when Map extend', function* () {
+      /* eslint-disable */
+      Map.prototype.test = function() {
+        console.log('test Map extend');
+      };
+      /* eslint-enable */
+      yield app.runSchedule(schedule);
+    });
   });
 
   describe('rotate_by_size', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
日志切割部分

##### Description of change
<!-- Provide a description of the change below this comment. -->
当应用中扩展了 Map 对象时，遍历 logger 属性会出现 file not undefine 错误