### PR TITLE
fix: clean log should use transport options file

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "egg": "^2.0.0",
     "egg-bin": "^4.9.0",
     "egg-ci": "^1.10.0",
+    "egg-logger": "^2.3.2",
     "egg-mock": "^3.20.1",
     "eslint": "^5.7.0",
     "eslint-config-egg": "^7.1.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
clean_log

##### Description of change
<!-- Provide a description of the change below this comment. -->
clean_log should use transport options as input