### PR TITLE
fix: hour crontab

### DIFF
--- a/app/schedule/rotate_by_hour.js
+++ b/app/schedule/rotate_by_hour.js
@@ -10,7 +10,7 @@ module.exports = app => {
 
     schedule: {
       type: 'worker', // only one worker run this task
-      cron: '0 * * * *', // run every hour at 00
+      cron: '1 * * * *', // run every hour at 01
       disable: (app.config.logrotator.filesRotateByHour || []).length === 0,
     },
 


### PR DESCRIPTION
Sometimes there is a problem with the moment calculation result when the scheduler is executed.

for example：

2024-09-25 11:00:00,000 ERROR 410 /4ms SCHEDULE /__schedule] nodejs.Error: [egg-logrotator] rename /home/admin/logs/egg/egg-web.log, found exception: targetFile /home/admin/logs/egg/egg-web.log.2024-09-25_09 exists!!

The calculation result of moment is 9 instead of 10, causing an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the scheduling of a task to run one minute past the hour, improving timing accuracy for task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->